### PR TITLE
Added support for F1-F24 keys

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -4,8 +4,9 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShortcutConfig {
+    #[serde(default)]
     pub modifiers: Vec<String>, // ["shift", "meta", "ctrl", "alt"]
-    pub key: String,            // "A", "M", etc.
+    pub key: String, // "A", "M", "F13", etc.
 }
 
 impl Default for ShortcutConfig {

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -53,6 +53,30 @@ fn code_from_str(key: &str) -> Code {
         "X" => Code::KeyX,
         "Y" => Code::KeyY,
         "Z" => Code::KeyZ,
+        "F1" => Code::F1,
+        "F2" => Code::F2,
+        "F3" => Code::F3,
+        "F4" => Code::F4,
+        "F5" => Code::F5,
+        "F6" => Code::F6,
+        "F7" => Code::F7,
+        "F8" => Code::F8,
+        "F9" => Code::F9,
+        "F10" => Code::F10,
+        "F11" => Code::F11,
+        "F12" => Code::F12,
+        "F13" => Code::F13,
+        "F14" => Code::F14,
+        "F15" => Code::F15,
+        "F16" => Code::F16,
+        "F17" => Code::F17,
+        "F18" => Code::F18,
+        "F19" => Code::F19,
+        "F20" => Code::F20,
+        "F21" => Code::F21,
+        "F22" => Code::F22,
+        "F23" => Code::F23,
+        "F24" => Code::F24,
         _ => Code::KeyA,
     }
 }
@@ -108,6 +132,23 @@ mod tests {
     fn test_code_from_str_lowercase() {
         assert!(matches!(code_from_str("a"), Code::KeyA));
         assert!(matches!(code_from_str("v"), Code::KeyV));
+    }
+
+    #[test]
+    fn test_code_from_str_function_keys() {
+        assert!(matches!(code_from_str("F1"), Code::F1));
+        assert!(matches!(code_from_str("F13"), Code::F13));
+        assert!(matches!(code_from_str("F24"), Code::F24));
+    }
+
+    #[test]
+    fn test_hotkey_from_config_no_modifiers() {
+        let config = ShortcutConfig {
+            modifiers: vec![],
+            key: "F13".to_string(),
+        };
+        let mods = modifiers_from_config(&config);
+        assert!(mods.is_empty());
     }
 
     #[test]

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -79,12 +79,38 @@ fn muda_code(key: &str) -> Code {
         "X" => Code::KeyX,
         "Y" => Code::KeyY,
         "Z" => Code::KeyZ,
+        "F1" => Code::F1,
+        "F2" => Code::F2,
+        "F3" => Code::F3,
+        "F4" => Code::F4,
+        "F5" => Code::F5,
+        "F6" => Code::F6,
+        "F7" => Code::F7,
+        "F8" => Code::F8,
+        "F9" => Code::F9,
+        "F10" => Code::F10,
+        "F11" => Code::F11,
+        "F12" => Code::F12,
+        "F13" => Code::F13,
+        "F14" => Code::F14,
+        "F15" => Code::F15,
+        "F16" => Code::F16,
+        "F17" => Code::F17,
+        "F18" => Code::F18,
+        "F19" => Code::F19,
+        "F20" => Code::F20,
+        "F21" => Code::F21,
+        "F22" => Code::F22,
+        "F23" => Code::F23,
+        "F24" => Code::F24,
         _ => Code::KeyA,
     }
 }
 
 fn accelerator_from_config(config: &ShortcutConfig) -> Accelerator {
-    Accelerator::new(Some(muda_modifiers(config)), muda_code(&config.key))
+    let mods = muda_modifiers(config);
+    let mods = if mods.is_empty() { None } else { Some(mods) };
+    Accelerator::new(mods, muda_code(&config.key))
 }
 
 unsafe impl Send for Tray {}


### PR DESCRIPTION
This PR fixes three issues that were preventing function keys (e.g. F13) from being used as shortcuts without modifier keys. This is particularly useful for advanced/customizable keyboards that have extra function keys or can reassign keys.

settings.rs
modifiers was missing #[serde(default)], so omitting it from settings.json caused the config to silently fail to parse and fall back to the default shift+meta+A.

shortcuts.rs
code_from_str only handled A–Z, so any function key would hit the _ => Code::KeyA fallback and register the wrong hotkey.

tray.rs
muda_code had the same A–Z-only limitation, causing the menu item to display "A" instead of the configured key. Also updated accelerator_from_config to pass None instead of Some(empty) when no modifiers are set, so the accelerator renders correctly in the menu.

With these changes, a config like { "key": "F13" } (no modifiers) now works correctly as both a global hotkey and in the tray menu display.